### PR TITLE
fix(match): convert matched value to lower case

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,5 +27,8 @@ function createMatchesObject<T extends PropertiesSchema>(hit: RetrievedDoc<T>, t
 }
 
 function checkValue(value: any, term: string | number | boolean): boolean {
-  return (typeof value === "string" && (value as string).includes(term as string)) || ((typeof value === "number" || typeof value === "boolean") && value === term)
+  return (
+    (typeof value === "string" && value.toString().toLowerCase().includes(term.toString().toLowerCase())) ||
+    ((typeof value === "number" || typeof value === "boolean") && value === term)
+  )
 }

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -67,3 +67,45 @@ test("match", ({test, plan}) => {
     end()
   })
 })
+
+test("errors", ({test, plan}) => {
+  plan(2)
+
+  const lyra = create({
+    schema: {
+      author: "string",
+      quote: "string"
+    }
+  })
+
+  insert(lyra, {
+    author: "Oscar Wilde",
+    quote: "Be yourself; everyone else is already taken."
+  })
+
+  test("properties should be retrieved event with different word cases", ({same, end}) => {
+    const params = {term: "oscar"} as SearchParams<typeof lyra.schema>
+    const {hits} = search(lyra, params)
+    const matches = match(hits, params).map(removeId)
+
+    same(matches, [
+      {
+        author: "Oscar Wilde"
+      }
+    ])
+    end()
+  })
+
+  test("properties should be retrieved event with different word cases", ({same, end}) => {
+    const params = {term: "EVERYONE"} as SearchParams<typeof lyra.schema>
+    const {hits} = search(lyra, params)
+    const matches = match(hits, params).map(removeId)
+
+    same(matches, [
+      {
+        quote: "Be yourself; everyone else is already taken."
+      }
+    ])
+    end()
+  })
+})


### PR DESCRIPTION
This PR fixes #3 by convert the value and the term into _lower case_.

